### PR TITLE
fix compile error

### DIFF
--- a/src/phev.c
+++ b/src/phev.c
@@ -479,7 +479,7 @@ bool phev_isACError(phevCtx_t * ctx)
 
     int error = phev_service_getACError(ctx->serviceCtx);
     LOG_V(TAG,"END - errACinfo");
-    return error == 3 // errACinfo. True if Door is Open or Main battery level is Low.
+    return error == 3; // errACinfo. True if Door is Open or Main battery level is Low.
 }
 
 


### PR DESCRIPTION
Fixes the following error:

```
[ 87%] Building C object CMakeFiles/phev.dir/src/phev.c.o
/src/phevcore/src/phev.c: In function 'phev_isACError':
/src/phevcore/src/phev.c:482:22: error: expected ';' before '}' token
  482 |     return error == 3 // errACinfo. True if Door is Open or Main battery level is Low.
      |                      ^
      |                      ;
  483 | }
      | ~                     
make[2]: *** [CMakeFiles/phev.dir/build.make:141: CMakeFiles/phev.dir/src/phev.c.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:76: CMakeFiles/phev.dir/all] Error 2
make: *** [Makefile:130: all] Error 2
```
