### PR TITLE
Adds numerical option to enable phevctl numerical output

### DIFF
--- a/include/phev.h
+++ b/include/phev.h
@@ -77,6 +77,7 @@ typedef struct phevSettings_t {
     uint16_t port;
     bool registerDevice;
     uint8_t * mac;
+    bool numerical;   
     phevEventHandler_t handler;
     void * ctx;
     bool my18;


### PR DESCRIPTION
I want to make it possible for phevctl to output only numerical values. This demands a small change in phevcore. 